### PR TITLE
Add Claude branch protection hook

### DIFF
--- a/.claude/hooks/enforce-branch-creation.sh
+++ b/.claude/hooks/enforce-branch-creation.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+CURRENT_BRANCH=$(cd "$CLAUDE_PROJECT_DIR" && git rev-parse --abbrev-ref HEAD)
+PROTECTED_BRANCHES=("main" "master" "develop")
+
+for branch in "${PROTECTED_BRANCHES[@]}"; do
+  if [ "$CURRENT_BRANCH" = "$branch" ]; then
+    echo "Cannot make changes on '$CURRENT_BRANCH' branch. Please create a new branch first." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-branch-creation.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds branch protection hooks to prevent Claude from making changes directly on protected branches.

## Changes Made

- Added `.claude/hooks/enforce-branch-creation.sh` - Prevents changes on main/master/develop
- Added `.claude/settings.json` - Configures hook to run on Write/Edit operations

## Technical Approach

When Claude attempts to write or edit files while on a protected branch, the hook will fail with:
"Cannot make changes on 'main' branch. Please create a new branch first."

This ensures all changes go through PR review, matching the pattern used across all MPI repos.

## Testing

Attempt to edit a file on main branch with Claude - it should be blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)