### PR TITLE
Add rspec_options input to ci-rails workflow

### DIFF
--- a/.github/workflows/ci-rails.yml
+++ b/.github/workflows/ci-rails.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: true
         type: boolean
+      rspec_options:
+        description: 'Additional options passed to the rspec command (e.g. --exclude-pattern or path filters)'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   scan_ruby:
@@ -167,7 +172,7 @@ jobs:
         run: bin/rails spec:prepare css:build
 
       - name: Run tests
-        run: bundle exec rspec --format RSpec::Github::Formatter --format progress
+        run: bundle exec rspec --format RSpec::Github::Formatter --format progress ${{ inputs.rspec_options }}
 
   # Test job with Elasticsearch
   test_with_elasticsearch:
@@ -235,4 +240,4 @@ jobs:
         run: bin/rails spec:prepare css:build
 
       - name: Run tests
-        run: bundle exec rspec --format RSpec::Github::Formatter --format progress
+        run: bundle exec rspec --format RSpec::Github::Formatter --format progress ${{ inputs.rspec_options }}


### PR DESCRIPTION
## Summary
Add a new optional `rspec_options` string input to the `ci-rails.yml` reusable workflow, allowing callers to pass additional flags to the `bundle exec rspec` command.

## Changes Made
- Added `rspec_options` input (type: string, default: empty, not required) to the `workflow_call` inputs in `.github/workflows/ci-rails.yml`
- Appended `${{ inputs.rspec_options }}` to the rspec command in both the `test` and `test_with_elasticsearch` jobs

## Technical Approach
The input is appended to the end of the existing rspec command. When no value is provided (default empty string), the command behaves identically to before — shell word splitting on an empty string produces no additional arguments.

This approach was chosen over alternatives like:
- A dedicated `test_pattern` input — too narrow, doesn't support `--exclude-pattern` or `--tag` flags
- Multiple boolean inputs for common patterns — not flexible enough for varied use cases across projects

## Use Case
Projects can now call `ci-rails.yml` twice in parallel to split their test suite:

```yaml
jobs:
  specs:
    uses: mpimedia/mpi-application-workflows/.github/workflows/ci-rails.yml@main
    with:
      rspec_options: '--exclude-pattern "spec/features/**/*_spec.rb"'

  feature_specs:
    uses: mpimedia/mpi-application-workflows/.github/workflows/ci-rails.yml@main
    with:
      rspec_options: '--pattern "spec/features/**/*_spec.rb"'
```

This lets slow browser-based feature specs run on a separate runner without blocking fast unit/request spec feedback.

## Testing
- Verified the YAML syntax is valid
- The change is backward-compatible: existing callers that don't pass `rspec_options` get the same behavior as before (empty string appended = no change)
- Will be validated end-to-end via the SFA repo's CI after this merges

## Checklist
- [x] YAML syntax validated
- [x] Backward-compatible (default empty string)
- [x] Both test jobs updated (with and without Elasticsearch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)