### PR TITLE
feat: Add jsbundling support for JS dependency auditing

### DIFF
--- a/.github/workflows/ci-rails.yml
+++ b/.github/workflows/ci-rails.yml
@@ -14,7 +14,7 @@ on:
         default: false
         type: boolean
       security_scan:
-        description: 'Run security scans (Brakeman, bundler-audit, importmap audit)'
+        description: 'Run security scans (Brakeman, bundler-audit, JS audit)'
         required: false
         default: true
         type: boolean
@@ -24,9 +24,14 @@ on:
         default: true
         type: boolean
       importmap:
-        description: 'Run importmap audit (disable for projects using esbuild/webpack)'
+        description: 'Run importmap audit for projects using importmap-rails'
         required: false
         default: true
+        type: boolean
+      jsbundling:
+        description: 'Run yarn npm audit for projects using jsbundling-rails (esbuild/webpack)'
+        required: false
+        default: false
         type: boolean
       rspec_options:
         description: 'Additional options passed to the rspec command (e.g. --exclude-pattern or path filters)'
@@ -59,7 +64,7 @@ jobs:
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit
 
-  scan_js:
+  scan_js_importmap:
     if: ${{ inputs.security_scan == true && inputs.importmap == true }}
     runs-on: ubuntu-latest
 
@@ -79,6 +84,30 @@ jobs:
 
       - name: Scan for security vulnerabilities in JavaScript dependencies
         run: bin/importmap audit
+
+  scan_js_jsbundling:
+    if: ${{ inputs.security_scan == true && inputs.jsbundling == true }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Read .tool-versions
+        uses: marocchino/tool-versions-action@v1
+        id: versions
+
+      - name: Install node
+        uses: actions/setup-node@v6
+        with:
+          cache: "yarn"
+          node-version: ${{ steps.versions.outputs.nodejs }}
+
+      - name: Install node packages
+        run: yarn install
+
+      - name: Scan for security vulnerabilities in JavaScript dependencies
+        run: yarn npm audit
 
   lint:
     if: ${{ inputs.lint == true }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains reusable GitHub Actions workflows used across all MPI M
 
 Full CI pipeline for Rails applications including:
 - Ruby security scanning (Brakeman, Bundler Audit)
-- JavaScript security scanning (Importmap Audit)
+- JavaScript security scanning (Importmap Audit or Yarn Audit)
 - Linting (RuboCop)
 - Test suite (RSpec with PostgreSQL)
 - Optional Elasticsearch support
@@ -22,6 +22,12 @@ Full CI pipeline for Rails applications including:
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `elasticsearch` | boolean | `false` | Enable Elasticsearch service for tests |
+| `libvips` | boolean | `false` | Install libvips for image processing |
+| `security_scan` | boolean | `true` | Run security scans (Brakeman, bundler-audit, JS audit) |
+| `lint` | boolean | `true` | Run RuboCop linting |
+| `importmap` | boolean | `true` | Run importmap audit for projects using importmap-rails |
+| `jsbundling` | boolean | `false` | Run yarn npm audit for projects using jsbundling-rails (esbuild/webpack) |
+| `rspec_options` | string | `''` | Additional options passed to the rspec command |
 
 When `elasticsearch: true`, the workflow:
 - Reads the Elasticsearch version from `.tool-versions`
@@ -93,6 +99,28 @@ jobs:
 **Note:** The Elasticsearch version is read from your project's `.tool-versions` file:
 ```
 elasticsearch 9.2.4
+```
+
+### CI Pipeline (With jsbundling)
+
+For projects using esbuild or webpack via jsbundling-rails:
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  ci:
+    uses: mpimedia/mpi-application-workflows/.github/workflows/ci-rails.yml@main
+    with:
+      importmap: false
+      jsbundling: true
+    secrets: inherit
 ```
 
 ### Gem Updates


### PR DESCRIPTION
## Summary

Projects using jsbundling-rails (esbuild/webpack) previously had no JS security audit in CI. When `importmap: false` was set, the `scan_js` job was skipped entirely with no alternative. This adds a `jsbundling` input that runs `yarn npm audit` for those projects.

## Changes Made

- **`.github/workflows/ci-rails.yml`**:
  - Added `jsbundling` input (boolean, default `false`)
  - Renamed `scan_js` job to `scan_js_importmap` for clarity
  - Added new `scan_js_jsbundling` job that sets up Node and runs `yarn npm audit`
  - Updated `security_scan` and `importmap` input descriptions
- **`README.md`**:
  - Complete inputs table (was previously only showing `elasticsearch`)
  - Added jsbundling usage example
  - Updated JS scanning description

## Technical Approach

Two separate jobs (`scan_js_importmap` and `scan_js_jsbundling`) rather than conditional steps in a single job. This keeps each job focused and avoids installing unnecessary toolchains (Ruby for jsbundling projects, Node for importmap projects).

The `jsbundling` input defaults to `false` to maintain full backwards compatibility — existing callers are unaffected.

## Affected Projects

Projects that should adopt `jsbundling: true` after this merges:
- **wpa_film_library (SFA)** — uses esbuild via jsbundling-rails
- **garden** — uses esbuild, currently sets `importmap: false`
- **harvest** — uses esbuild, currently sets `importmap: false`

## Testing

- Verified `yarn npm audit` passes on wpa_film_library locally
- Workflow syntax validated (YAML structure, input types, conditional expressions)

## Checklist

- [x] Workflow syntax is valid
- [x] Backwards compatible (jsbundling defaults to false)
- [x] README updated with complete documentation
- [x] PR description provides sufficient context

:robot: Generated with [Claude Code](https://claude.com/claude-code)