### PR TITLE
Set up RAILS_MASTER_KEY from secrets when running tests

### DIFF
--- a/.github/workflows/ci-rails.yml
+++ b/.github/workflows/ci-rails.yml
@@ -148,6 +148,7 @@ jobs:
 
     env:
       RAILS_ENV: test
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
 
     services:
       postgres:
@@ -211,6 +212,7 @@ jobs:
     env:
       RAILS_ENV: test
       ELASTICSEARCH_URL: http://localhost:9200
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

This pull request sets up `RAILS_MASTER_KEY` as an environment variable for the `test` and `test_with_elasticsearch` jobs in the reusable CI Rails workflow.

## Changes Made

Some tests in repos (such as Avails) are written to access the Rails credentials, and fail without `RAILS_MASTER_KEY` set up. I added it as an environment variable for the jobs that run tests (`test` and `test_with_elasticsearch`).

Since the workflows are being called with `secrets: inherit`, the value will come from the repository's secrets if they're set. If the repo does not have the `RAILS_MASTER_KEY` secret set up in it, it'll simply return an empty string which Rails should ignore.

## Testing

I can't test fully until it gets merged and we run it against a repo that has the `RAILS_MASTER_KEY` secret set up. I set up the secret in Avails, so we can test it there.

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [x] Changes are documented in code comments where non-obvious
- [x] PR description provides sufficient context
