### PR TITLE
Fix: Switch notifications from SMTP to Postmark HTTP API

### DIFF
--- a/.github/workflows/check-indexes.yml
+++ b/.github/workflows/check-indexes.yml
@@ -22,25 +22,42 @@ jobs:
     if: failure()
     steps:
       - name: Send failure notification
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.postmarkapp.com
-          server_port: 587
-          secure: false
-          username: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
-          password: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
-          subject: "❌ GitHub Action Failed: ${{ github.repository }} – ${{ github.workflow }}"
-          to: ${{ secrets.WORKFLOW_TO_EMAIL }}
-          from: ${{ secrets.WORKFLOW_FROM_EMAIL }}
-          body: |
-            Workflow:  ${{ github.workflow }}
-            Branch:    ${{ github.ref_name }}
-            Commit:    ${{ github.event.head_commit.message || 'N/A' }}
-            SHA:       ${{ github.sha }}
-            Author:    ${{ github.actor }}
-            Triggered: ${{ github.event_name }}
+        env:
+          POSTMARK_TOKEN: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
+          WORKFLOW_FROM: ${{ secrets.WORKFLOW_FROM_EMAIL }}
+          WORKFLOW_TO: ${{ secrets.WORKFLOW_TO_EMAIL }}
+        run: |
+          SUBJECT="\u274c GitHub Action Failed: ${{ github.repository }} \u2013 ${{ github.workflow }}"
+          BODY=$(cat <<'BODY_EOF'
+          Workflow:  ${{ github.workflow }}
+          Branch:    ${{ github.ref_name }}
+          Commit:    ${{ github.event.head_commit.message || 'N/A' }}
+          SHA:       ${{ github.sha }}
+          Author:    ${{ github.actor }}
+          Triggered: ${{ github.event_name }}
 
-            Job Results:
-              check-indexes: ${{ needs.check-indexes.result }}
+          Job Results:
+            check-indexes: ${{ needs.check-indexes.result }}
 
-            View run:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          View run:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BODY_EOF
+          )
+          JSON=$(jq -n \
+            --arg from "$WORKFLOW_FROM" \
+            --arg to "$WORKFLOW_TO" \
+            --arg subject "$SUBJECT" \
+            --arg body "$BODY" \
+            '{From: $from, To: $to, Subject: $subject, TextBody: $body}')
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "https://api.postmarkapp.com/email" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -H "X-Postmark-Server-Token: $POSTMARK_TOKEN" \
+            -d "$JSON")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          RESP_BODY=$(echo "$RESPONSE" | head -n -1)
+          echo "Postmark response (HTTP $HTTP_CODE): $RESP_BODY"
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Postmark API returned HTTP $HTTP_CODE: $RESP_BODY"
+            exit 1
+          fi

--- a/.github/workflows/ci-rails.yml
+++ b/.github/workflows/ci-rails.yml
@@ -280,30 +280,47 @@ jobs:
     if: always() && contains(needs.*.result, 'failure')
     steps:
       - name: Send failure notification
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.postmarkapp.com
-          server_port: 587
-          secure: false
-          username: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
-          password: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
-          subject: "❌ GitHub Action Failed: ${{ github.repository }} – ${{ github.workflow }}"
-          to: ${{ secrets.WORKFLOW_TO_EMAIL }}
-          from: ${{ secrets.WORKFLOW_FROM_EMAIL }}
-          body: |
-            Workflow:  ${{ github.workflow }}
-            Branch:    ${{ github.ref_name }}
-            Commit:    ${{ github.event.head_commit.message || 'N/A' }}
-            SHA:       ${{ github.sha }}
-            Author:    ${{ github.actor }}
-            Triggered: ${{ github.event_name }}
+        env:
+          POSTMARK_TOKEN: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
+          WORKFLOW_FROM: ${{ secrets.WORKFLOW_FROM_EMAIL }}
+          WORKFLOW_TO: ${{ secrets.WORKFLOW_TO_EMAIL }}
+        run: |
+          SUBJECT="\u274c GitHub Action Failed: ${{ github.repository }} \u2013 ${{ github.workflow }}"
+          BODY=$(cat <<'BODY_EOF'
+          Workflow:  ${{ github.workflow }}
+          Branch:    ${{ github.ref_name }}
+          Commit:    ${{ github.event.head_commit.message || 'N/A' }}
+          SHA:       ${{ github.sha }}
+          Author:    ${{ github.actor }}
+          Triggered: ${{ github.event_name }}
 
-            Job Results:
-              scan_ruby:              ${{ needs.scan_ruby.result }}
-              scan_js_importmap:      ${{ needs.scan_js_importmap.result }}
-              scan_js_jsbundling:     ${{ needs.scan_js_jsbundling.result }}
-              lint:                   ${{ needs.lint.result }}
-              test:                   ${{ needs.test.result }}
-              test_with_elasticsearch: ${{ needs.test_with_elasticsearch.result }}
+          Job Results:
+            scan_ruby:              ${{ needs.scan_ruby.result }}
+            scan_js_importmap:      ${{ needs.scan_js_importmap.result }}
+            scan_js_jsbundling:     ${{ needs.scan_js_jsbundling.result }}
+            lint:                   ${{ needs.lint.result }}
+            test:                   ${{ needs.test.result }}
+            test_with_elasticsearch: ${{ needs.test_with_elasticsearch.result }}
 
-            View run:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          View run:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BODY_EOF
+          )
+          JSON=$(jq -n \
+            --arg from "$WORKFLOW_FROM" \
+            --arg to "$WORKFLOW_TO" \
+            --arg subject "$SUBJECT" \
+            --arg body "$BODY" \
+            '{From: $from, To: $to, Subject: $subject, TextBody: $body}')
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "https://api.postmarkapp.com/email" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -H "X-Postmark-Server-Token: $POSTMARK_TOKEN" \
+            -d "$JSON")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          RESP_BODY=$(echo "$RESPONSE" | head -n -1)
+          echo "Postmark response (HTTP $HTTP_CODE): $RESP_BODY"
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Postmark API returned HTTP $HTTP_CODE: $RESP_BODY"
+            exit 1
+          fi

--- a/.github/workflows/update-gems.yml
+++ b/.github/workflows/update-gems.yml
@@ -30,25 +30,42 @@ jobs:
     if: failure()
     steps:
       - name: Send failure notification
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.postmarkapp.com
-          server_port: 587
-          secure: false
-          username: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
-          password: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
-          subject: "❌ GitHub Action Failed: ${{ github.repository }} – ${{ github.workflow }}"
-          to: ${{ secrets.WORKFLOW_TO_EMAIL }}
-          from: ${{ secrets.WORKFLOW_FROM_EMAIL }}
-          body: |
-            Workflow:  ${{ github.workflow }}
-            Branch:    ${{ github.ref_name }}
-            Commit:    ${{ github.event.head_commit.message || 'N/A' }}
-            SHA:       ${{ github.sha }}
-            Author:    ${{ github.actor }}
-            Triggered: ${{ github.event_name }}
+        env:
+          POSTMARK_TOKEN: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
+          WORKFLOW_FROM: ${{ secrets.WORKFLOW_FROM_EMAIL }}
+          WORKFLOW_TO: ${{ secrets.WORKFLOW_TO_EMAIL }}
+        run: |
+          SUBJECT="\u274c GitHub Action Failed: ${{ github.repository }} \u2013 ${{ github.workflow }}"
+          BODY=$(cat <<'BODY_EOF'
+          Workflow:  ${{ github.workflow }}
+          Branch:    ${{ github.ref_name }}
+          Commit:    ${{ github.event.head_commit.message || 'N/A' }}
+          SHA:       ${{ github.sha }}
+          Author:    ${{ github.actor }}
+          Triggered: ${{ github.event_name }}
 
-            Job Results:
-              update-gems: ${{ needs.update-gems.result }}
+          Job Results:
+            update-gems: ${{ needs.update-gems.result }}
 
-            View run:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          View run:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BODY_EOF
+          )
+          JSON=$(jq -n \
+            --arg from "$WORKFLOW_FROM" \
+            --arg to "$WORKFLOW_TO" \
+            --arg subject "$SUBJECT" \
+            --arg body "$BODY" \
+            '{From: $from, To: $to, Subject: $subject, TextBody: $body}')
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "https://api.postmarkapp.com/email" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -H "X-Postmark-Server-Token: $POSTMARK_TOKEN" \
+            -d "$JSON")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          RESP_BODY=$(echo "$RESPONSE" | head -n -1)
+          echo "Postmark response (HTTP $HTTP_CODE): $RESP_BODY"
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Postmark API returned HTTP $HTTP_CODE: $RESP_BODY"
+            exit 1
+          fi

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -36,25 +36,42 @@ jobs:
     if: failure()
     steps:
       - name: Send failure notification
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.postmarkapp.com
-          server_port: 587
-          secure: false
-          username: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
-          password: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
-          subject: "❌ GitHub Action Failed: ${{ github.repository }} – ${{ github.workflow }}"
-          to: ${{ secrets.WORKFLOW_TO_EMAIL }}
-          from: ${{ secrets.WORKFLOW_FROM_EMAIL }}
-          body: |
-            Workflow:  ${{ github.workflow }}
-            Branch:    ${{ github.ref_name }}
-            Commit:    ${{ github.event.head_commit.message || 'N/A' }}
-            SHA:       ${{ github.sha }}
-            Author:    ${{ github.actor }}
-            Triggered: ${{ github.event_name }}
+        env:
+          POSTMARK_TOKEN: ${{ secrets.POSTMARK_NOTIFICATIONS_SMTP_TOKEN }}
+          WORKFLOW_FROM: ${{ secrets.WORKFLOW_FROM_EMAIL }}
+          WORKFLOW_TO: ${{ secrets.WORKFLOW_TO_EMAIL }}
+        run: |
+          SUBJECT="\u274c GitHub Action Failed: ${{ github.repository }} \u2013 ${{ github.workflow }}"
+          BODY=$(cat <<'BODY_EOF'
+          Workflow:  ${{ github.workflow }}
+          Branch:    ${{ github.ref_name }}
+          Commit:    ${{ github.event.head_commit.message || 'N/A' }}
+          SHA:       ${{ github.sha }}
+          Author:    ${{ github.actor }}
+          Triggered: ${{ github.event_name }}
 
-            Job Results:
-              update-packages: ${{ needs.update-packages.result }}
+          Job Results:
+            update-packages: ${{ needs.update-packages.result }}
 
-            View run:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          View run:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BODY_EOF
+          )
+          JSON=$(jq -n \
+            --arg from "$WORKFLOW_FROM" \
+            --arg to "$WORKFLOW_TO" \
+            --arg subject "$SUBJECT" \
+            --arg body "$BODY" \
+            '{From: $from, To: $to, Subject: $subject, TextBody: $body}')
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "https://api.postmarkapp.com/email" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -H "X-Postmark-Server-Token: $POSTMARK_TOKEN" \
+            -d "$JSON")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          RESP_BODY=$(echo "$RESPONSE" | head -n -1)
+          echo "Postmark response (HTTP $HTTP_CODE): $RESP_BODY"
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Postmark API returned HTTP $HTTP_CODE: $RESP_BODY"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Replaces the `dawidd6/action-send-mail@v3` SMTP action with direct `curl` calls to the Postmark HTTP API in all 4 workflow notification jobs. The SMTP action is broken with Postmark — this fixes it.

## Why

PR #7 was merged with the SMTP-based approach before the API fix could land. During end-to-end testing in Garden, the SMTP action consistently produced a `501 5.1.7 Bad sender address syntax` error — even with hardcoded, valid email addresses. The Postmark HTTP API works correctly with the same token and sender.

| Approach | Result |
|---|---|
| SMTP action (`dawidd6/action-send-mail@v3`) | `501 5.1.7 Bad sender address syntax` |
| Postmark HTTP API (direct curl) | **200 OK — email delivered** |

## Changes

- **All 4 workflows** (`check-indexes.yml`, `ci-rails.yml`, `update-gems.yml`, `update-packages.yml`): Replace `dawidd6/action-send-mail@v3` step with a `curl` + `jq` script that POSTs to `https://api.postmarkapp.com/email`
- Secrets passed via `env:` block for cleaner masking
- `jq` safely constructs JSON (handles special characters in commit messages, branch names, etc.)
- No changes needed in consuming repos — they still use `secrets: inherit`

## Testing

Verified in `mpimedia/garden` with a dedicated test workflow:
- Postmark HTTP API returned `200 OK` and email was delivered to `applications@mpimedia.com`
- Test workflow has been cleaned up (Garden PR #388)

🤖 Generated with [Claude Code](https://claude.com/claude-code)