### PR TITLE
Update shared deploy workflow to ping Tailscale hosts and set up SSH config on runner

### DIFF
--- a/.github/workflows/deploy-kamal.yml
+++ b/.github/workflows/deploy-kamal.yml
@@ -7,8 +7,8 @@ on:
         description: "Target environment"
         required: true
         type: string
-      tailscale_ping:
-        description: "Comma-separated list of Tailscale hosts to ping after connection"
+      tailscale_hosts:
+        description: 'Comma-separated Tailscale host addresses (e.g. "host1,host2")'
         required: false
         type: string
         default: ""
@@ -51,7 +51,13 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           audience: ${{ secrets.TS_AUDIENCE }}
           tags: tag:ci
-          ping: ${{ inputs.tailscale_ping }}
+          ping: ${{ inputs.tailscale_hosts }}
+
+      - name: Set up SSH config to accept new Tailscale hosts
+        run: |
+          mkdir -p ~/.ssh
+          echo "StrictHostKeyChecking accept-new" >> ~/.ssh/config
+          chmod 600 ~/.ssh/config
 
       - name: Install 1Password CLI
         uses: 1password/install-cli-action@v2

--- a/.github/workflows/deploy-kamal.yml
+++ b/.github/workflows/deploy-kamal.yml
@@ -7,6 +7,11 @@ on:
         description: "Target environment"
         required: true
         type: string
+      tailscale_ping:
+        description: "Comma-separated list of Tailscale hosts to ping after connection"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -46,6 +51,7 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           audience: ${{ secrets.TS_AUDIENCE }}
           tags: tag:ci
+          ping: ${{ inputs.tailscale_ping }}
 
       - name: Install 1Password CLI
         uses: 1password/install-cli-action@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ MPI Application Workflows provides shared, reusable GitHub Actions CI/CD workflo
 | `update-gems.yml` | Daily automated gem updates | — |
 | `update-packages.yml` | Daily automated package updates | — |
 | `check-indexes.yml` | Migration index validation | — |
-| `deploy-kamal.yml` | Kamal deployment (staging/production) | `environment` |
+| `deploy-kamal.yml` | Kamal deployment (staging/production) | `environment`, `tailscale_hosts` |
 
 All workflows support failure notifications via Postmark API.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Deployment via Kamal:
 - Deploys Rails applications using Kamal
 - Supports staging and production environments
 - Uses Tailscale for secure network connectivity to deployment targets
+- Optionally pings Tailscale hosts to verify connectivity before deploying
+- Configures SSH to automatically accept new Tailscale host keys
 - Uses 1Password CLI for secrets management
 - Configures Docker buildx with GitHub Actions cache
 
@@ -68,6 +70,7 @@ Deployment via Kamal:
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `environment` | string | *(required)* | Target environment (`staging` or `production`) |
+| `tailscale_hosts` | string | `""` | Comma-separated Tailscale host addresses to ping for connectivity verification (e.g. `"host1,host2"`) |
 
 ## Usage
 
@@ -219,6 +222,7 @@ jobs:
     uses: mpimedia/mpi-application-workflows/.github/workflows/deploy-kamal.yml@main
     with:
       environment: ${{ inputs.environment }}
+      tailscale_hosts: "web-server,worker-server"
     secrets: inherit
 ```
 


### PR DESCRIPTION
## Summary

This pull request is a follow-up to #19 to handle a couple of issues that I found when trying to use Tailscale for the shared deployment workflow.

## Changes Made

- Updated `.github/workflows/deploy-kamal.yml`:
  - Added a new input called `tailscale_hosts`, which will accept a comma-separated string with the Tailscale hostnames.
  - Updated the Tailscale setup step with the `ping` option, which will ensure that the runner can access the specified hostnames passed from the consumer.
  - Added a new step to set up a basic `~/.ssh/config` file to automatically accept the SSH host keys so there's no issue when running SSH commands in the Kamal buiild/deploy step

## Testing

I ran some temporary tests on a Garden branch that I'm setting up with Tailscale and the deploy is working successfully: https://github.com/mpimedia/garden/actions/runs/24181326208/job/70574756230

## Checklist

- [x] Changes are documented in code comments where non-obvious
- [x] PR description provides sufficient context
