### PR TITLE
chore: remove Markaz CRM from agent docs and project registry

### DIFF
--- a/.claude/projects.json
+++ b/.claude/projects.json
@@ -48,14 +48,6 @@
       "github_repo": "harvest",
       "role": "ecommerce"
     },
-    "markez_crm": {
-      "name": "Markaz CRM",
-      "description": "CRM application (planned merge into Markaz/avails_server)",
-      "github_url": "https://github.com/mpimedia/markez-crm",
-      "github_org": "mpimedia",
-      "github_repo": "markez-crm",
-      "role": "crm"
-    },
     "infrastructure": {
       "name": "MPI Infrastructure",
       "description": "Terraform infrastructure and deployment configuration",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ This file provides guidance for GitHub Copilot coding agents working with this r
 
 ## Project Overview
 
-**MPI Application Workflows** provides shared, reusable GitHub Actions CI/CD workflows consumed by all MPI Media Rails applications (Optimus, Markaz, SFA, Garden, Harvest, Markaz CRM). This is NOT a Rails app — it contains only GitHub Actions YAML workflow files.
+**MPI Application Workflows** provides shared, reusable GitHub Actions CI/CD workflows consumed by all MPI Media Rails applications (Optimus, Markaz, SFA, Garden, Harvest). This is NOT a Rails app — it contains only GitHub Actions YAML workflow files.
 
 ## Workflows
 
@@ -20,7 +20,7 @@ All are callable workflows (`workflow_call`) pinned by SHA in consumer repos.
 
 ## Key Constraints
 
-- **Breaking changes require consumer coordination** — 6+ repos depend on these workflows
+- **Breaking changes require consumer coordination** — 5+ repos depend on these workflows
 - **Workflow filenames must not change** — consumers reference by path
 - **Never add secrets to workflow files** — use `secrets` context
 - **Test from a consumer repo** before merging — no local test infrastructure exists
@@ -32,4 +32,4 @@ Every AI agent **must** include attribution: `Co-Authored-By` trailer on commits
 
 ## Consumer Repos
 
-Optimus, Markaz (avails_server), SFA (wpa_film_library), Garden, Harvest, Markaz CRM (markez-crm) — all under `mpimedia/` org.
+Optimus, Markaz (avails_server), SFA (wpa_film_library), Garden, Harvest — all under `mpimedia/` org.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions for all AI coding agents (Claude Code, Copilot, Codex, and others) 
 
 ## Project Identity
 
-MPI Application Workflows provides **shared, reusable GitHub Actions CI/CD workflows** consumed by all MPI Media Rails applications. This is NOT a Rails app — it contains only GitHub Actions YAML workflow files. Changes here affect 6+ consumer repos.
+MPI Application Workflows provides **shared, reusable GitHub Actions CI/CD workflows** consumed by all MPI Media Rails applications. This is NOT a Rails app — it contains only GitHub Actions YAML workflow files. Changes here affect 5+ consumer repos.
 
 ## Workflows
 
@@ -28,7 +28,6 @@ All are callable workflows (`workflow_call`) referenced by consumers via pinned 
 | SFA | `mpimedia/wpa_film_library` | Consumer |
 | Garden | `mpimedia/garden` | Consumer |
 | Harvest | `mpimedia/harvest` | Consumer |
-| Markaz CRM | `mpimedia/markez-crm` | Consumer |
 
 ## Pre-Commit Requirements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## About This Project
 
-MPI Application Workflows provides shared, reusable GitHub Actions CI/CD workflows consumed by all MPI Media Rails applications. Changes to these workflows affect the entire ecosystem — Optimus, Markaz, SFA, Garden, Harvest, and Markaz CRM all pin to a specific commit SHA for stability.
+MPI Application Workflows provides shared, reusable GitHub Actions CI/CD workflows consumed by all MPI Media Rails applications. Changes to these workflows affect the entire ecosystem — Optimus, Markaz, SFA, Garden, and Harvest all pin to a specific commit SHA for stability.
 
 ## Workflows
 
@@ -95,5 +95,4 @@ These are non-negotiable. Never do any of the following:
 | SFA | `mpimedia/wpa_film_library` | Consumer |
 | Garden | `mpimedia/garden` | Consumer |
 | Harvest | `mpimedia/harvest` | Consumer |
-| Markaz CRM | `mpimedia/markez-crm` | Consumer |
 | Infrastructure | `mpimedia/mpi-infrastructure` | Separate (Terraform) |


### PR DESCRIPTION
## Summary

Markaz CRM is sunsetted. The GitHub repo `mpimedia/markaz-crm` was archived on **2026-05-13**. This PR removes all references from this repo's agent docs and project registry.

This is one of a series of cross-repo follow-ups to Markaz PR [#1147](https://github.com/mpimedia/markaz/pull/1147), which removed Markaz CRM from the Markaz repo's agent docs.

## Changes Made

| File | Change |
|------|--------|
| `AGENTS.md` | Drop "Markaz CRM" row from the MPI Application Ecosystem table; update consumer count "6+" -> "5+" |
| `CLAUDE.md` | Remove "and Markaz CRM" from ecosystem prose; drop "Markaz CRM" row from the ecosystem table |
| `.github/copilot-instructions.md` | Remove "Markaz CRM" from the project-overview consumer list and the Consumer Repos section; update "6+ repos" -> "5+ repos" |
| `.claude/projects.json` | Remove the `markez_crm` entry entirely. Note: the registry entry used the misspelled `markez-crm` slug; the actual (now archived) GitHub repo is `mpimedia/markaz-crm` |

## What's NOT in this PR

- **Workflow YAML files** — I grepped `.github/workflows/*.yml` for `markez|markaz.crm|markaz_crm|markez_crm|crm` and found zero matches. No workflow conditionally targets `markaz-crm`, and no job matrix lists it. Nothing to change there.
- **Shell scripts** — none referenced Markaz CRM.
- **README.md** — clean, no references.

## Testing

Doc/config-only change. No YAML or workflow source touched.

- Validated `.claude/projects.json` with `python3 -m json.tool` — valid JSON
- Re-grepped entire repo (excluding `.git/`) for `markez|markaz.crm|markaz_crm|markez_crm` after the edits — zero matches remain
- Broader sanity grep for standalone `\bcrm\b` — zero matches remain

## Checklist

- [x] All four target files edited
- [x] `.claude/projects.json` validates as JSON
- [x] No Markaz CRM references remain anywhere in the repo
- [x] Workflow YAML files inspected and found clean (no flag needed)
- [x] Markaz CRM GitHub repo archived (2026-05-13, per HC)

— Claude Code (Opus 4.7)