### PR TITLE
Do not auto-update Bundler in the gem update script (respect cooldown)

### DIFF
--- a/scripts/update-gems
+++ b/scripts/update-gems
@@ -92,10 +92,14 @@ LOCK_PLATFORMS="$(ruby "$GEMFILE_EDIT" platforms Gemfile.lock)"
 echo -e "${YELLOW}Stripping exact pins from uncommented gems...${NC}"
 ruby "$GEMFILE_EDIT" unpin Gemfile
 
-echo -e "${YELLOW}Updating bundler to latest version...${NC}"
-gem install bundler --no-document
-bundle update --bundler
-
+# Bundler itself is deliberately NOT auto-updated here. `gem install bundler`
+# and `bundle update --bundler` fetch the newest Bundler outside the Gemfile
+# cooldown, and since Bundler executes on every `bundle install`, that would
+# be the largest hole in the cooldown guarantee. The lockfile's `BUNDLED WITH`
+# governs the version (ruby/setup-ruby installs it); bumping Bundler is a
+# deliberate, reviewed change to that line, never an automatic weekly one.
+# (Requires the app's pinned Bundler to be >= 4.0.13 for cooldown support;
+# the `cooldown:` source option fails loudly otherwise.)
 echo -e "${YELLOW}Resolving fresh lockfile (cooldown enforced by Bundler)...${NC}"
 rm Gemfile.lock
 bundle lock --add-checksums


### PR DESCRIPTION
## Summary

Follow-up to #22, fixing a **P1 from Codex's review of [optimus#428](https://github.com/mpimedia/optimus/pull/428)**: the centralized `scripts/update-gems` auto-updated Bundler itself outside the cooldown, undercutting the supply-chain guarantee.

## Problem

```bash
gem install bundler --no-document   # fetches newest Bundler, bypasses bundle's cooldown entirely
bundle update --bundler             # writes that newest version to BUNDLED WITH
```

The Gemfile `cooldown:` option filters **gems resolved from the source** — it does not apply to `gem install bundler`. So the weekly automation could adopt a same-day Bundler release. Since Bundler executes on every `bundle install`, that's the highest-value target in the whole dependency graph to leave un-gated.

## Fix

Remove both lines. Consequences:
- The lockfile's `BUNDLED WITH` governs the Bundler version; `ruby/setup-ruby` (bundler-cache) installs exactly that version on the runner.
- Bumping Bundler becomes a deliberate, reviewed edit to `BUNDLED WITH` (as optimus#428 itself does, 4.0.12 → 4.0.13), never an automatic weekly jump.
- Apps must pin Bundler ≥ 4.0.13 for cooldown support — the `cooldown:` source option errors loudly if not, so no explicit guard is added.

## Testing

- `DRY_RUN=true` against the Optimus pilot checkout (Bundler 4.0.13): exits 0, **`BUNDLED WITH` unchanged** in the would-be lockfile diff (previously this run bumped it)
- `shellcheck scripts/update-gems scripts/update-packages` — clean
- `ruby scripts/test/gemfile_edit_test.rb` — 21 assertions pass

## Checklist

- [x] shellcheck + fixture tests green
- [x] Dry-run confirms Bundler no longer auto-bumped
- [x] No other behavior changed (only the two bundler-self-update lines removed)

Refs mpimedia/optimus#425, mpimedia/optimus#428

— Claude Code (Opus 4.8)