### PR TITLE
Update gems in place to keep the lockfile consistent and cross-platform

### DIFF
--- a/scripts/lib/gemfile_edit.rb
+++ b/scripts/lib/gemfile_edit.rb
@@ -145,9 +145,19 @@ def lockdiff(old_lock_path, new_lock_path)
   end
 end
 
-def platforms(lockfile_path)
+# Unique non-"ruby" platforms that appear on resolved gem specs — i.e. the set
+# of precompiled platform variants the lockfile carries (e.g. arm64-darwin,
+# aarch64-linux). Used to assert an update never drops a platform's variants
+# (which would break that platform's `bundle install --frozen`). This is the
+# gem-variant platform set, distinct from the lockfile's PLATFORMS section.
+def platform_variants(lockfile_path)
   parser = Bundler::LockfileParser.new(File.read(lockfile_path))
-  parser.platforms.each { |platform| puts platform }
+  parser.specs
+        .map { |spec| spec.platform.to_s }
+        .reject { |platform| platform == "ruby" }
+        .uniq
+        .sort
+        .each { |platform| puts platform }
 end
 
 def usage!
@@ -157,7 +167,7 @@ def usage!
       gemfile_edit.rb repin <original_gemfile> <lockfile> <gemfile> [--floor <original_lockfile>]
       gemfile_edit.rb comments <gemfile>
       gemfile_edit.rb lockdiff <old_lockfile> <new_lockfile>
-      gemfile_edit.rb platforms <lockfile>
+      gemfile_edit.rb platform_variants <lockfile>
   USAGE
 end
 
@@ -179,9 +189,9 @@ when "comments"
 when "lockdiff"
   usage! unless ARGV.length == 3
   lockdiff(ARGV[1], ARGV[2])
-when "platforms"
+when "platform_variants"
   usage! unless ARGV.length == 2
-  platforms(ARGV[1])
+  platform_variants(ARGV[1])
 else
   usage!
 end

--- a/scripts/test/gemfile_edit_test.rb
+++ b/scripts/test/gemfile_edit_test.rb
@@ -170,9 +170,12 @@ Dir.mktmpdir do |dir|
   assert_equal(EXPECTED_REPIN_UPDATED, File.read(gemfile), "repin --floor (newer resolved) content")
   assert_equal("", stdout, "repin --floor (newer resolved) reports nothing")
 
-  puts "platforms lists lockfile platforms"
-  stdout, = run_mode("platforms", File.join(FIXTURES, "Gemfile.lock.updated"))
-  assert_equal("arm64-darwin\nruby\n", stdout, "platforms output")
+  puts "platform_variants lists precompiled gem-variant platforms (excludes ruby)"
+  stdout, = run_mode("platform_variants", File.join(FIXTURES, "Gemfile.lock.updated"))
+  assert_equal("arm64-darwin\n", stdout, "platform_variants output (has a variant)")
+
+  stdout, = run_mode("platform_variants", File.join(FIXTURES, "Gemfile.lock.same"))
+  assert_equal("", stdout, "platform_variants output (no variants)")
 
   puts "comments lists skipped gems"
   stdout, = run_mode("comments", original)

--- a/scripts/update-gems
+++ b/scripts/update-gems
@@ -85,49 +85,57 @@ trap on_error ERR
 # --- Record gems held back by Gemfile comments (never touched) ---
 SKIPPED_GEMS="$(ruby "$GEMFILE_EDIT" comments Gemfile)"
 
-# --- Preserve the lockfile's platform list (a fresh lock would lose it) ---
-LOCK_PLATFORMS="$(ruby "$GEMFILE_EDIT" platforms Gemfile.lock)"
-
-# --- Unpin -> fresh resolve under cooldown -> repin with floor ---
-echo -e "${YELLOW}Stripping exact pins from uncommented gems...${NC}"
+# Phase 1 — discover target versions under the cooldown.
+#
+# A fresh `bundle lock` (no existing lockfile) resolves cleanly under the
+# cooldown, whereas `bundle update --all` / `bundle lock --update` FAIL when a
+# currently-locked version is younger than the cooldown window (Bundler hides
+# in-window versions from resolution, even ones already in the lockfile). This
+# throwaway lock is used ONLY to learn the target versions — it is not the
+# lockfile we ship. Regenerating from scratch would de-pin the DEPENDENCIES
+# section and drop platform-specific gem variants locked on other OSes
+# (e.g. arm64-darwin builds resolved on a developer's Mac), so the real
+# lockfile is updated in place in Phase 3 instead.
+#
+# Bundler itself is deliberately NOT auto-updated: `gem install bundler` /
+# `bundle update --bundler` bypass the cooldown and Bundler runs on every
+# install. The lockfile's `BUNDLED WITH` governs the version (ruby/setup-ruby
+# installs it); bumping it is a deliberate, reviewed change. Apps must pin
+# Bundler >= 4.0.13 for cooldown support (the source option errors otherwise).
+echo -e "${YELLOW}Discovering target versions under the cooldown...${NC}"
 ruby "$GEMFILE_EDIT" unpin Gemfile
-
-# Bundler itself is deliberately NOT auto-updated here. `gem install bundler`
-# and `bundle update --bundler` fetch the newest Bundler outside the Gemfile
-# cooldown, and since Bundler executes on every `bundle install`, that would
-# be the largest hole in the cooldown guarantee. The lockfile's `BUNDLED WITH`
-# governs the version (ruby/setup-ruby installs it); bumping Bundler is a
-# deliberate, reviewed change to that line, never an automatic weekly one.
-# (Requires the app's pinned Bundler to be >= 4.0.13 for cooldown support;
-# the `cooldown:` source option fails loudly otherwise.)
-echo -e "${YELLOW}Resolving fresh lockfile (cooldown enforced by Bundler)...${NC}"
 rm Gemfile.lock
 bundle lock --add-checksums
+TARGET_LOCK="$(mktemp)"
+cp Gemfile.lock "$TARGET_LOCK"
 
-echo -e "${YELLOW}Restoring lockfile platforms...${NC}"
-ADD_PLATFORM_ARGS=()
-while IFS= read -r PLATFORM; do
-  [ -z "$PLATFORM" ] && continue
-  ADD_PLATFORM_ARGS+=("$PLATFORM")
-done <<< "$LOCK_PLATFORMS"
-if [ ${#ADD_PLATFORM_ARGS[@]} -gt 0 ]; then
-  bundle lock --add-checksums --add-platform "${ADD_PLATFORM_ARGS[@]}"
-fi
+# Phase 2 — re-pin the Gemfile to the resolved targets, never below the version
+# already locked (an in-window locked version stays put rather than rolling
+# back to an older cooldown-eligible release).
+echo -e "${YELLOW}Re-pinning Gemfile to resolved versions (never downgrading)...${NC}"
+FLOORED_GEMS="$(ruby "$GEMFILE_EDIT" repin "$ORIG_GEMFILE" "$TARGET_LOCK" Gemfile --floor "$ORIG_LOCK")"
 
-echo -e "${YELLOW}Re-pinning Gemfile from resolved lockfile versions (never below the previously locked version)...${NC}"
-FLOORED_GEMS="$(ruby "$GEMFILE_EDIT" repin "$ORIG_GEMFILE" Gemfile.lock Gemfile --floor "$ORIG_LOCK")"
-
+# Phase 3 — apply the new pins to the ORIGINAL lockfile. Restoring the original
+# lock first means only the gems whose pins actually changed get re-resolved;
+# every other gem keeps its exact lockfile entry, including platform-specific
+# variants, and the DEPENDENCIES section is regenerated to match the re-pinned
+# Gemfile. This is what keeps the lockfile consistent and cross-platform.
+echo -e "${YELLOW}Applying updates to the existing lockfile...${NC}"
+cp "$ORIG_LOCK" Gemfile.lock
 if [ -n "$FLOORED_GEMS" ]; then
-  # One or more gems are pinned above what the cooldown-filtered resolution
-  # produced (their already-locked versions are inside the cooldown window).
-  # Sync the lockfile to those pins with the cooldown disabled: every direct
-  # gem is exact-pinned at this point, so this re-admits only versions the
-  # app already ships — it cannot select anything new.
   echo -e "${YELLOW}Keeping already-locked in-window versions (no downgrades):${NC}"
   echo "$FLOORED_GEMS" | awk -F'\t' '{ printf "  - %s: resolver chose %s, keeping locked %s\n", $2, $3, $4 }'
-  # `bundle lock` has no --cooldown flag; the env var has the same precedence.
-  BUNDLE_COOLDOWN=0 bundle lock --add-checksums
 fi
+# Realize the pins with the cooldown DISABLED. Every direct gem is now exact-
+# pinned to a version that was already vetted under the cooldown in Phase 1
+# (or floored to a version the app already ships), so disabling it here adds
+# nothing new — it only avoids a re-resolution flake when a target sits exactly
+# on the cooldown boundary (Phase 1 would admit it; a second cooldown pass
+# seconds later might not). `bundle install` (not `bundle lock`) because only
+# install reliably applies a changed pin, and it is exactly what the
+# idempotence guard and developers run. (`bundle` has no --cooldown flag; the
+# env var has the same precedence.)
+BUNDLE_COOLDOWN=0 bundle install >/dev/null
 
 UPDATED_GEMS="$(ruby "$GEMFILE_EDIT" lockdiff "$ORIG_LOCK" Gemfile.lock)"
 
@@ -136,6 +144,43 @@ if git diff --quiet Gemfile Gemfile.lock 2>/dev/null; then
   echo -e "${GREEN}✓ No gem updates available within the cooldown window.${NC}"
   restore_originals
   exit 0
+fi
+
+# Phase 4 — idempotence guard. The generated lockfile MUST be a fixed point of
+# a plain (cooldown-respecting) `bundle install`; otherwise frozen CI/production
+# installs would fail and every developer's `bundle install` would churn it.
+# Compare the lockfile immediately before and after one more install — NOT
+# against HEAD, which legitimately differs by the updates we just made. Any
+# change here means the resolve left the lockfile inconsistent (e.g. an
+# in-window transitive that a cooldown install would reject) — restore and
+# abort so the workflow's failure notification fires instead of opening a
+# broken PR.
+echo -e "${YELLOW}Verifying the lockfile is idempotent...${NC}"
+GUARD_LOCK="$(mktemp)"
+cp Gemfile.lock "$GUARD_LOCK"
+bundle install >/dev/null
+if ! diff -q "$GUARD_LOCK" Gemfile.lock >/dev/null 2>&1; then
+  echo -e "${RED}Lockfile is not idempotent — a follow-up 'bundle install' changed it:${NC}"
+  diff "$GUARD_LOCK" Gemfile.lock | head -60
+  restore_originals
+  exit 1
+fi
+
+# Phase 5 — platform-variant guard. A precompiled variant (e.g. arm64-darwin)
+# present in the original lockfile must still be present, or that platform's
+# `bundle install --frozen` would break. Updating a gem in place preserves
+# unchanged gems' variants, but re-resolving a *changed* platform gem on a
+# Linux runner can silently drop its non-Linux variants — the idempotence
+# guard can't see that (a Linux install is self-consistent without them).
+echo -e "${YELLOW}Verifying platform variants are preserved...${NC}"
+MISSING_PLATFORMS="$(comm -23 \
+  <(ruby "$GEMFILE_EDIT" platform_variants "$ORIG_LOCK") \
+  <(ruby "$GEMFILE_EDIT" platform_variants Gemfile.lock))"
+if [ -n "$MISSING_PLATFORMS" ]; then
+  echo -e "${RED}Lockfile dropped platform variants that were present before:${NC}"
+  echo "$MISSING_PLATFORMS" | awk '{ print "  - " $0 }'
+  restore_originals
+  exit 1
 fi
 
 # --- Build PR content ---


### PR DESCRIPTION
## Summary

Fixes the lockfile corruption found by `/dep-review` of [optimus#437](https://github.com/mpimedia/optimus/pull/437) — the first real run of the centralized `update-gems` script. Follow-up to #22/#23.

## Problem (optimus#437)

The generated `Gemfile.lock` was broken two ways:
1. **`DEPENDENCIES` de-pinned** — `awesome_print (= 1.9.2)` → `awesome_print` for every gem.
2. **`arm64-darwin` variants dropped** — `nokogiri`/`pg`/`thruster` lost their precompiled Apple-Silicon builds.

A plain `bundle install` rewrote the committed lockfile (62/60 lines), so `bundle install --frozen` (Kamal/deploy) would fail and every dev's install would churn. **Root cause:** the script regenerated the whole lockfile from a fresh `bundle lock`, which de-pins DEPENDENCIES and, on a Linux runner, drops variants locked on a developer's Mac.

## Fix — discover, then apply in place

- **Phase 1** (unchanged): fresh `bundle lock` under the cooldown, used *only* to discover target versions (resolves cleanly where `bundle update --all` fails on in-window locked versions).
- **Phase 2** (unchanged): re-pin the Gemfile to those targets, with the never-downgrade floor.
- **Phase 3** (NEW): restore the **original** lockfile, then `BUNDLE_COOLDOWN=0 bundle install`. Only gems whose pin changed are re-resolved; every other gem keeps its exact entry (incl. platform variants) and DEPENDENCIES is regenerated from the re-pinned Gemfile. Cooldown disabled here because the pins were already vetted under it in Phase 1 — this also fixes a re-resolution flake when a target sits exactly on the cooldown boundary. `bundle install` (not `bundle lock`) because only install reliably applies a changed pin.

## Two guards (abort → failure notification, never a broken PR)

- **Idempotence:** a follow-up cooldown-respecting `bundle install` must not change the lockfile — compared *before/after that install*, not vs HEAD (comparing vs HEAD was a bug in my first draft: it flagged the legitimate update).
- **Platform variants:** every precompiled variant present before (e.g. `arm64-darwin`) must still be present — catches a *changed* platform gem losing its non-Linux builds on a Linux runner, which the idempotence guard can't see (a Linux install is self-consistent without them).

`gemfile_edit`: replaced the unused `platforms` mode with `platform_variants` (the gem-variant platform set the guard needs).

## Testing

Verified against the Optimus pilot checkout (Bundler 4.0.13):
- Dry run exits 0; both guards pass.
- Would-be lockfile keeps **DEPENDENCIES pinned** and all **6 arm64-darwin variant lines**.
- **Idempotent** under a cooldown-on `bundle install`.
- **`bundle install --frozen` succeeds** — the exact check optimus#437 failed.
- `shellcheck`, `actionlint`, and the `gemfile_edit` fixture tests (incl. new `platform_variants` cases) pass.

The real proof is re-running the dispatch on the Linux runner after merge (how #437's bug surfaced) — the guards mean a regression aborts rather than ships.

Refs mpimedia/optimus#425, mpimedia/optimus#437

— Claude Code (Opus 4.8)